### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/brimstone/go-domainglass.png?label=ready&title=Ready)](https://waffle.io/brimstone/go-domainglass)
 domainglass
 ===========
 [![Build Status](https://travis-ci.org/brimstone/go-domainglass.svg?branch=master)](https://travis-ci.org/brimstone/go-domainglass)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/brimstone/go-domainglass

This was requested by a real person (user brimstone) on waffle.io, we're not trying to spam you.
